### PR TITLE
Provide default value for ETC_DIR

### DIFF
--- a/DenyHosts/prefs.py
+++ b/DenyHosts/prefs.py
@@ -60,7 +60,8 @@ class Prefs(dict):
                        'SYNC_DOWNLOAD_THRESHOLD': 3,
                        'SYNC_DOWNLOAD_RESILIENCY': '5h',
                        'PURGE_THRESHOLD': 0,
-                       'ALLOWED_HOSTS_HOSTNAME_LOOKUP': 'no'}
+                       'ALLOWED_HOSTS_HOSTNAME_LOOKUP': 'no',
+                       'ETC_DIR': '/etc'}
 
         # reqd[0]: required field name
         # reqd[1]: is value required? (False = value can be blank)
@@ -74,7 +75,7 @@ class Prefs(dict):
                      ('PURGE_DENY', False),
                      ('HOSTS_DENY', True),
                      ('WORK_DIR', True),
-                     ('ETC_DIR', True),
+                     ('ETC_DIR', False),
                      ('IPTABLES', False),
                      ('BLOCKPORT', False),
                      ('PFCTL_PATH', False),


### PR DESCRIPTION
in Fedora (and I suspect most distros) we don't overwrite configuration
files when a package is upgraded.  This means that all existing Fedora
machines with denyhosts installed have denyhosts.conf files without
ETC_DIR, and if I push a new package then it will break all running
Fedora installs, which would be bad.