### PR TITLE
Convert one character to UTF-8

### DIFF
--- a/CHANGELOG.txt
+++ b/CHANGELOG.txt
@@ -354,7 +354,7 @@ insure info logging stream is active.
 
 - added 1 second sleep between stop & start in daemon-control-dist for "restart" command.
 
-- Added ShoreWall plugins (thanks to Stéphane LeDauphin for the contribution).
+- Added ShoreWall plugins (thanks to StÃ©phane LeDauphin for the contribution).
 
 - Fixed licensing ambiguity (DenyHosts is GPL v2).
 


### PR DESCRIPTION
This is a tiny annoying one-character thing I have to fix in the Fedora package, since we require all documentation to be in UTF-8.