### PR TITLE
Systemd journal implementation

### DIFF
--- a/DenyHosts/constants.py
+++ b/DenyHosts/constants.py
@@ -5,6 +5,7 @@ import sys
 #################################################################################
 
 SECURE_LOG_OFFSET = "offset"
+SECURE_LOG_CURSOR = "journald-cursor"
 DENIED_TIMESTAMPS = "denied-timestamps"
 
 ABUSIVE_HOSTS_INVALID = "hosts"

--- a/DenyHosts/deny_hosts.py
+++ b/DenyHosts/deny_hosts.py
@@ -61,12 +61,15 @@ class DenyHosts(object):
         self.init_regex()
 
         self.__allowed_hosts = AllowedHosts(self.__prefs)
+        last_offset = None
 
         if self.__use_journal:
             # If cursor exists, seek to it.  Otherwise read all entries.
             self.__cursor_file = os.path.join(self.__prefs.get('WORK_DIR'), SECURE_LOG_CURSOR)
             self.__cursor = ""
             self.__journal = journal.Reader()
+            self.__journal.add_match('SYSLOG_IDENTIFIER=sshd')
+            self.__journal.get_next()
 
             try:
                 fp = open(self.__cursor_file, "r")
@@ -229,7 +232,7 @@ class DenyHosts(object):
                 # Have processed all pending journal entries; save off the cursor
                 try:
                     fp = open(self.__cursor_file, "w")
-                    fp.write(cursor)
+                    fp.write(str(cursor))
                     fp.write("\n")
                     fp.close()
                 except IOError:

--- a/DenyHosts/deny_hosts.py
+++ b/DenyHosts/deny_hosts.py
@@ -165,9 +165,9 @@ class DenyHosts(object):
         self.__lock_file.create()
 
         if self.__use_journal:
-            info("monitoring journal")
+            info("Monitoring journal")
         else:
-            info("monitoring log: %s", logfile)
+            info("Monitoring log: {0}".format(logfile))
         daemon_sleep = self.__prefs.get('DAEMON_SLEEP')
         purge_time = self.__prefs.get('PURGE_DENY')
         sync_time = self.__prefs.get('SYNC_INTERVAL')
@@ -436,7 +436,7 @@ allowed based on your %s file"""  % (self.__prefs.get("HOSTS_DENY"),
         except Exception, e:
             print "Could not open log file: %s" % logfile
             print e
-            return -1
+            return None
 
         try:
             fp.seek(offset)
@@ -524,6 +524,10 @@ allowed based on your %s file"""  % (self.__prefs.get("HOSTS_DENY"),
         else:
             self.get_denied_hosts()
             fp = self.open_log_and_seek(logfile, offset)
+            # If the log couldn't be opened, return a negative offset
+            # so the main loop will keep trying.
+            if fp == None:
+                return -1
             for line in fp:
                 success = invalid = 0
                 m = None
@@ -565,7 +569,7 @@ allowed based on your %s file"""  % (self.__prefs.get("HOSTS_DENY"),
                 try:
                     host = m.group("host")
                 except Exception:
-                    error("regex pattern ( %s ) is missing 'host' group" % m.re.pattern)
+                    error("Regex pattern ( {0} ) is missing 'host' group".format(m.re.pattern))
                     continue
 
                 debug("user: {0} - host: {1} - success: {2} - invalid: {3}".format(user, host, success, invalid))
@@ -584,9 +588,9 @@ allowed based on your %s file"""  % (self.__prefs.get("HOSTS_DENY"),
             new_denied_hosts, status = self.update_hosts_deny(deny_hosts)
             if new_denied_hosts:
                 if not status:
-                    msg = "WARNING: Could not add the following hosts to %s" % self.__prefs.get('HOSTS_DENY')
+                    msg = "WARNING: Could not add the following hosts to {0}".format(self.__prefs.get('HOSTS_DENY'))
                 else:
-                    msg = "Added the following hosts to %s" % self.__prefs.get('HOSTS_DENY')
+                    msg = "Added the following hosts to {0}".format(self.__prefs.get('HOSTS_DENY'))
                 self.__report.add_section(msg, new_denied_hosts)
                 if self.__sync_server: self.sync_add_hosts(new_denied_hosts)
                 plugin_deny = self.__prefs.get('PLUGIN_DENY')
@@ -657,13 +661,13 @@ allowed based on your %s file"""  % (self.__prefs.get("HOSTS_DENY"),
             fp = open(self.__cursor_file, "r")
             self.__cursor = fp.readline().rstrip("\r\n")
         except IOError:
-            pass
+            self.__cursor = ""
 
     def save_cursor(self, cursor):
         if not cursor:
             return
 
-        debug("Updating cursor file to {}".format(cursor))
+        debug("Updating cursor file to {0}".format(cursor))
         self.__cursor = cursor
         try:
             fp = open(self.__cursor_file, "w")
@@ -671,7 +675,7 @@ allowed based on your %s file"""  % (self.__prefs.get("HOSTS_DENY"),
             fp.write("\n")
             fp.close()
         except IOError:
-            error("Could not save cursor to %s" % self.__cursor_file)
+            error("Could not save cursor to {0}".format(self.__cursor_file))
 
 
 ##        self.__failed_entry_regex = self.get_regex('FAILED_ENTRY_REGEX', FAILED_ENTRY_REGEX)

--- a/DenyHosts/deny_hosts.py
+++ b/DenyHosts/deny_hosts.py
@@ -216,8 +216,6 @@ class DenyHosts(object):
             # If using the journal, we can always just iterate over any new entries
             if self.__use_journal:
                 cursor = self.process_log(None, None)
-                if cursor:
-                    debug("Cursor: {0}".format(cursor))
                 self.save_cursor(cursor)
 
             # If not using the journal....
@@ -517,8 +515,8 @@ allowed based on your %s file"""  % (self.__prefs.get("HOSTS_DENY"),
             # Need to record the cursor here if we got any entries at all
             if entry:
                 offset = entry['__CURSOR']
-            else:
-                debug("Processed no new entries")
+            #else:
+                #debug("Processed no new entries")
 
         # Not using the journal....
         else:

--- a/DenyHosts/deny_hosts.py
+++ b/DenyHosts/deny_hosts.py
@@ -68,7 +68,12 @@ class DenyHosts(object):
             self.__cursor_file = os.path.join(self.__prefs.get('WORK_DIR'), SECURE_LOG_CURSOR)
             self.__cursor = ""
             self.__journal = journal.Reader()
-            self.__journal.add_match('SYSLOG_IDENTIFIER=sshd')
+
+            # Add each of the specified match strings, with logical OR between them
+            for match in prefs.get("JOURNAL_MATCHES").split():
+                self.__journal.add_match(match)
+                self.__journal.add_disjunction()
+
             self.__journal.get_next()
 
             self.read_cursor()

--- a/DenyHosts/loginattempt.py
+++ b/DenyHosts/loginattempt.py
@@ -51,6 +51,7 @@ class LoginAttempt(object):
 
 
     def add(self, user, host, success, invalid):
+        debug("Add: {0}, {1}".format(user, host))
         user_host_key = "%s - %s" % (user, host)
 
         if host:

--- a/DenyHosts/prefs.py
+++ b/DenyHosts/prefs.py
@@ -61,6 +61,9 @@ class Prefs(dict):
                        'SYNC_DOWNLOAD_RESILIENCY': '5h',
                        'PURGE_THRESHOLD': 0,
                        'ALLOWED_HOSTS_HOSTNAME_LOOKUP': 'no',
+                       'USE_JOURNAL': 'no',
+                       'JOURNAL_MATCHES': 'SYSLOG_IDENTIFIER=sshd',
+                       'LOG_TO_JOURNAL': 'no',
                        'ETC_DIR': '/etc'}
 
         # reqd[0]: required field name
@@ -79,7 +82,10 @@ class Prefs(dict):
                      ('IPTABLES', False),
                      ('BLOCKPORT', False),
                      ('PFCTL_PATH', False),
-                     ('PF_TABLE', False))
+                     ('PF_TABLE', False)
+                     ('USE_JOURNAL', False),
+                     ('JOURNAL_MATCHES', False),
+                     ('LOG_TO_JOURNAL': False))
 
         # the paths for these keys will be converted to
         # absolute pathnames (in the event they are relative)

--- a/DenyHosts/prefs.py
+++ b/DenyHosts/prefs.py
@@ -82,10 +82,10 @@ class Prefs(dict):
                      ('IPTABLES', False),
                      ('BLOCKPORT', False),
                      ('PFCTL_PATH', False),
-                     ('PF_TABLE', False)
+                     ('PF_TABLE', False),
                      ('USE_JOURNAL', False),
                      ('JOURNAL_MATCHES', False),
-                     ('LOG_TO_JOURNAL': False))
+                     ('LOG_TO_JOURNAL', False))
 
         # the paths for these keys will be converted to
         # absolute pathnames (in the event they are relative)

--- a/DenyHosts/util.py
+++ b/DenyHosts/util.py
@@ -22,7 +22,7 @@ def setup_logging(prefs, enable_debug, verbose, daemon):
         daemon_log = prefs.get('DAEMON_LOG')
         journal_log = is_true(prefs.get('LOG_TO_JOURNAL'))
         if journal_log:
-            logging.root.addHandler(journal.JournalHandler())
+            logging.root.addHandler(journal.JournalHandler(SYSLOG_IDENTIFIER='denyhosts'))
             logging.root.propagate = False
         elif daemon_log:
             # define a Handler which writes INFO messages or higher to the sys.stderr

--- a/DenyHosts/util.py
+++ b/DenyHosts/util.py
@@ -8,6 +8,11 @@ from textwrap import dedent
 import time
 from types import IntType
 
+try:
+    from systemd import journal
+except ImportError:
+    pass
+
 from constants import BSD_STYLE, TIME_SPEC_LOOKUP
 from regex import TIME_SPEC_REGEX
 
@@ -15,7 +20,11 @@ debug = logging.getLogger("util").debug
 
 def setup_logging(prefs, enable_debug, verbose, daemon):
         daemon_log = prefs.get('DAEMON_LOG')
-        if daemon_log:
+        journal_log = is_true(prefs.get('LOG_TO_JOURNAL'))
+        if journal_log:
+            logging.root.addHandler(journal.JournalHandler())
+            logging.root.propagate = False
+        elif daemon_log:
             # define a Handler which writes INFO messages or higher to the sys.stderr
             # fh = logging.FileHandler(daemon_log, 'a')
             fh = logging.handlers.RotatingFileHandler(daemon_log, 'a', 1024*1024, 7)
@@ -25,10 +34,10 @@ def setup_logging(prefs, enable_debug, verbose, daemon):
             fh.setFormatter(formatter)
             # add the handler to the root logger
             logging.getLogger().addHandler(fh)
+        if journal_log or daemon_log:
             if enable_debug:
                 # if --debug was enabled provide gory activity details
                 logging.getLogger().setLevel(logging.DEBUG)
-                #prefs.dump_to_logger()
             else:
                 # in daemon mode we always log some activity
                 logging.getLogger().setLevel(logging.INFO)

--- a/denyhosts.conf
+++ b/denyhosts.conf
@@ -541,6 +541,7 @@ AGE_RESET_INVALID=10d
 # this is the logfile that DenyHosts uses to report its status.
 # To disable logging, leave blank.  (default is: /var/log/denyhosts)
 #
+# Note: This is completely ignored if LOG_TO_JOURNAL is specified.
 DAEMON_LOG = /var/log/denyhosts
 #
 # disable logging:

--- a/denyhosts.conf
+++ b/denyhosts.conf
@@ -8,6 +8,7 @@
 # The file to process can be overridden with the --file command line
 # argument
 #
+# Note: this is completely ignored if USE_JOURNAL is specified. See below.
 # Redhat or Fedora Core:
 #SECURE_LOG = /var/log/secure
 #
@@ -26,6 +27,40 @@
 #
 # Debian and Ubuntu
 SECURE_LOG = /var/log/auth.log
+########################################################################
+
+########################################################################
+#
+# USE_JOURNAL: Instead of reading from a log file, read from the systemd
+# journal.  This requires the systemd python libraries to be installed,
+# and of course is pointless on a system without systemd.
+#
+# When this is enabled, SECURE_LOG is ignored, as is SSHD_FORMAT_REGEX.
+# To specify the units whose logs denyhosts will parse for login attempts,
+# see JOURNAL_UNITS.
+#
+#USE_JOURNAL=YES
+#
+# JOURNAL_MATCHES: A space-separated list of match strings, used to
+# specify the entries retrieved from the journal.  All entries which match
+# any of the supplied match strings will be processed to find failed login
+# attempts.
+#
+# There is no need to set this unless you want process log entries other
+# than those from sshd.
+#
+# Note that this could be _SYSTEMD_UNIT=sshd.service, except that if sshd is
+# socket-activated, the service name is completely unpredictable.
+#JOURNAL_MATCHES=SYSLOG_IDENTIFIER=sshd
+#
+# LOG_TO_JOURNAL: Instead of writing to a log file, log to the systemd journal
+# instead.
+#
+# When this is enabled, DAEMON_LOG is ignored, as are DAEMON_LOG_TIME_FORMAT
+# and DAEMON_LOG_MESSAGE_FORMAT.
+#
+#LOG_TO_JOURNAL=YES
+#
 ########################################################################
 
 ########################################################################

--- a/denyhosts.py
+++ b/denyhosts.py
@@ -9,6 +9,7 @@ import DenyHosts.python_version
 import getopt
 from getopt import GetoptError
 import traceback
+import logging
 
 from DenyHosts.util import die, setup_logging, is_true
 from DenyHosts.lockfile import LockFile


### PR DESCRIPTION
This implements an interface to the systemd journal.  Both logging output to the journal, as well as reading events from the journal are supported.  This is controlled by three new config options:

USE_JOURNAL - if YES, denyhosts will read events from the journal and will ignore completely the SECURE_LOG setting

JOURNAL_MATCHES - list of match strings passed to sd_journal_match(); no need to set it in most cases.

LOG_TO_JOURNAL - If YES, denyhosts will ignore DAEMON_LOG and instead log to the journal.

I am not particularly satisfied with the names of these options.  Suggestions are welcome.

I have tested this new code both reading from a standard syslog log file and from the journal and everything seems to work as expected.  There is still plenty of work to do to to make the code a bit less painful on the eyes.