### PR TITLE
Fixing line in readme so it renders correctly

### DIFF
--- a/README.md
+++ b/README.md
@@ -48,7 +48,7 @@ then edited as such:
 
     # <edit> /etc/denyhosts.conf
 
-(where <edit> is your preferred text editor such as emacs, vi, etc)
+(where \<edit\> is your preferred text editor such as emacs, vi, etc)
 
 The sample configuration file contains informational comments that
 should help you quickly configure DenyHosts.  After you have


### PR DESCRIPTION
Previously the line would read "where is your preferred..."

I've "escaped" the <> tags and this seems to make it render correctly in
a browser now and it reads "where <edit> is your preferred..."

Before:
![selection_001](https://cloud.githubusercontent.com/assets/5868863/6779069/245b7580-d150-11e4-8e90-5e92eb79965a.png)

After:
![selection_002](https://cloud.githubusercontent.com/assets/5868863/6779086/514ccc1a-d150-11e4-8cf5-ff791498ad0c.png)
