### PR TITLE
Fix unwonted cut in host name

### DIFF
--- a/DenyHosts/util.py
+++ b/DenyHosts/util.py
@@ -80,8 +80,6 @@ def parse_host(line):
 
     # convert form 3 & 4 to 1 & 2
     try:
-        line = line.strip(BSD_STYLE)
-
         vals = line.split(":")
 
         # we're only concerned about the ip_address


### PR DESCRIPTION
Python's strip(BSD_STYLE) work other way. It cuts all symbols in line being in BSD_STYLE. If resolve server names is on then some of names cut and as result they every time add to hosts.deny