### PR TITLE
Iptables block multiple ports

### DIFF
--- a/DenyHosts/deny_hosts.py
+++ b/DenyHosts/deny_hosts.py
@@ -339,7 +339,9 @@ allowed based on your %s file"""  % (self.__prefs.get("HOSTS_DENY"),
            try:
               for host in new_hosts:
                   my_host = str(host)
-                  if self.__blockport:
+                  if ',' in self.__blockport:
+                      new_rule = self.__iptables + " -I INPUT -p tcp --dports " + self.__blockport + " -s " + my_host + " -j DROP"
+                  elif self.__blockport:
                      new_rule = self.__iptables + " -I INPUT -p tcp --dport " + self.__blockport + " -s " + my_host + " -j DROP"
                   else:
                      new_rule = self.__iptables + " -I INPUT -s " + my_host + " -j DROP"

--- a/DenyHosts/deny_hosts.py
+++ b/DenyHosts/deny_hosts.py
@@ -340,7 +340,7 @@ allowed based on your %s file"""  % (self.__prefs.get("HOSTS_DENY"),
               for host in new_hosts:
                   my_host = str(host)
                   if ',' in self.__blockport:
-                      new_rule = self.__iptables + " -I INPUT -p tcp --dports " + self.__blockport + " -s " + my_host + " -j DROP"
+                      new_rule = self.__iptables + " -I INPUT -p tcp -m multiport --dports " + self.__blockport + " -s " + my_host + " -j DROP"
                   elif self.__blockport:
                      new_rule = self.__iptables + " -I INPUT -p tcp --dport " + self.__blockport + " -s " + my_host + " -j DROP"
                   else:

--- a/denyhosts.conf
+++ b/denyhosts.conf
@@ -249,8 +249,9 @@ IPTABLES = /sbin/iptables
 # By default DenyHost will ask IPTables to block incoming connections
 # from an aggressive host on ALL ports. While this is usually a good
 # idea, it may prevent some botted machines from being able to access
-# services their legitmate users want, like a web server. To only
-# block specific ports, enable the following option.
+# services their legitmate users want, like a web server. To 
+# block specific ports, enable the following option. Multiple ports may
+# be specified using a comma as a delimiter ex: 21,22,3306
 # BLOCKPORT = 22
 #
 #######################################################################


### PR DESCRIPTION
added the option that if a , exists within BLOCKPORT it will assume that multiple ports are being defined, and will enter the iptables rule to use -m multiport with --dports to reject the ports.  This adds further flexibility rather than saying deny all or just one port.