### PR TITLE
Multiple PLUGIN_DENY Arguments

### DIFF
--- a/DenyHosts/deny_hosts.py
+++ b/DenyHosts/deny_hosts.py
@@ -333,7 +333,16 @@ allowed based on your %s file"""  % (self.__prefs.get("HOSTS_DENY"),
             fp.write("%s\n" % output)
 
         plugin_deny = self.__prefs.get('PLUGIN_DENY')
-        if plugin_deny: plugin.execute(plugin_deny, new_hosts)
+        if ',' in plugin_deny:
+            #explode plugins by ,
+            m_plugin_deny=plugin_deny.split(',')
+            #loop through multiple plugins
+            for m_plugin in m_plugin_deny:
+                if m_plugin:
+                    plugin.execute(m_plugin.strip(), new_hosts)
+        else:
+            if plugin_deny: plugin.execute(plugin_deny, new_hosts)
+        
         if self.__iptables:
            debug("Trying to create iptables rules")
            try:
@@ -503,8 +512,15 @@ allowed based on your %s file"""  % (self.__prefs.get("HOSTS_DENY"),
             self.__report.add_section(msg, new_denied_hosts)
             if self.__sync_server: self.sync_add_hosts(new_denied_hosts)
             plugin_deny = self.__prefs.get('PLUGIN_DENY')
-
-            if plugin_deny: plugin.execute(plugin_deny, new_denied_hosts)
+            if ',' in plugin_deny:
+                #explode plugins by ,
+                m_plugin_deny=plugin_deny.split(',')
+                #loop through multiple plugins
+                for m_plugin in m_plugin_deny:
+                    if m_plugin:
+                        plugin.execute(m_plugin.strip(), new_hosts)
+            else:
+                if plugin_deny: plugin.execute(plugin_deny, new_denied_hosts)
 
         new_suspicious_logins = login_attempt.get_new_suspicious_logins()
         if new_suspicious_logins:

--- a/denyhosts.conf
+++ b/denyhosts.conf
@@ -474,7 +474,8 @@ AGE_RESET_INVALID=10d
 # PLUGIN_DENY: If set, this value should point to an executable
 # program that will be invoked when a host is added to the
 # HOSTS_DENY file.  This executable will be passed the host
-# that will be added as its only argument.
+# that will be added as its only argument. To run multiple plugins
+# separate the plugins by a comma ex /usr/bin/true,/usr/bin/false
 #
 #PLUGIN_DENY=/usr/bin/true
 #


### PR DESCRIPTION
Allowing multiple plugins to be defined in denyhosts.conf and ran in deny_hosts.py