### PR TITLE
python 2 compatibility user input, migrate unit test

### DIFF
--- a/DenyHosts/denyfileutil.py
+++ b/DenyHosts/denyfileutil.py
@@ -5,7 +5,7 @@ import logging
 
 from .constants import DENY_DELIMITER, ENTRY_DELIMITER
 from .loginattempt import AbusiveHosts
-from .util import parse_host
+from .util import parse_host, get_user_input
 from . import plugin
 from .purgecounter import PurgeCounter
 
@@ -63,10 +63,12 @@ class Migrate(DenyFileUtilBase):
         print("you won't purge")
         print("")
         print("If you don't understand, please type 'No' and")
-        print("read /usr/share/doc/denyhosts/README.Debian")
-        print("for more info")
+        print("refer to documentation for more info")
         print("")
-        response = input("Are you sure that you want do this? (Yes/No)")
+
+        prompt = "Are you sure that you want do this? (Yes/No)"
+        response = get_user_input(prompt)
+
         if response == "Yes":
             DenyFileUtilBase.__init__(self, deny_file, "migrate")
             self.backup()

--- a/DenyHosts/util.py
+++ b/DenyHosts/util.py
@@ -13,6 +13,7 @@ from .regex import TIME_SPEC_REGEX
 
 debug = logging.getLogger("util").debug
 
+
 def setup_logging(prefs, enable_debug, verbose, daemon):
         daemon_log = prefs.get('DAEMON_LOG')
         if daemon_log:
@@ -38,17 +39,21 @@ def setup_logging(prefs, enable_debug, verbose, daemon):
             info("   %s", ' '.join(sys.argv))
             prefs.dump_to_logger()
 
+
 def die(msg, ex=None):
     print(msg)
     if ex:
         print(ex)
     sys.exit(1)
 
+
 def is_true(s):
     return s.lower() in ('1', 't', 'true', 'y', 'yes')
 
+
 def is_false(s):
     return not is_true(s)
+
 
 def calculate_seconds(timestr, zero_ok=False):
     # return the number of seconds in a given timestr such as 1d (1 day),
@@ -68,6 +73,7 @@ def calculate_seconds(timestr, zero_ok=False):
     seconds = units * TIME_SPEC_LOOKUP[period]
     #info("converted %s to %ld seconds: ", timestr, seconds)
     return seconds
+
 
 def parse_host(line):
     # parses a line from /etc/hosts.deny
@@ -93,6 +99,7 @@ def parse_host(line):
     except Exception:
         host = ""
     return host
+
 
 def send_email(prefs, report_str):
     recipients = prefs['ADMIN_EMAIL'].split(',')
@@ -164,8 +171,10 @@ def send_email(prefs, report_str):
     except Exception:
         pass
 
+
 def normalize_whitespace(string):
     return ' '.join(string.split())
+
 
 def is_valid_ip_address(ip_address):
     try:
@@ -177,3 +186,11 @@ def is_valid_ip_address(ip_address):
         ip.is_link_local):
         return False
     return True
+
+
+def get_user_input(prompt):
+    try:
+        response = raw_input(prompt)
+    except NameError:
+        response = input(prompt)
+    return response

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,1 +1,2 @@
 ipaddr>=2.1
+mock ; python_version < '3.3'

--- a/tests/data/migrate/hosts.deny.template
+++ b/tests/data/migrate/hosts.deny.template
@@ -1,0 +1,17 @@
+# /etc/hosts.deny: list of hosts that are _not_ allowed to access the system.
+#                  See the manual pages hosts_access(5) and hosts_options(5).
+#
+# Example:    ALL: some.host.name, .some.domain
+#             ALL EXCEPT in.fingerd: other.host.name, .other.domain
+#
+# If you're going to protect the portmapper use the name "rpcbind" for the
+# daemon name. See rpcbind(8) and rpc.mountd(8) for further information.
+#
+# The PARANOID wildcard matches any host whose name does not match its
+# address.
+#
+# You may wish to enable this to ensure any programs that don't
+# validate looked up hostnames still leave understandable logs. In past
+# versions of Debian this has been the default.
+# ALL: PARANOID
+sshd: 79.202.22.222, 79.202.22.224

--- a/tests/test_migrate.py
+++ b/tests/test_migrate.py
@@ -1,0 +1,35 @@
+from os.path import dirname, join as ospj
+from os import remove
+import unittest
+import shutil
+import filecmp
+from DenyHosts.denyfileutil import Migrate
+from DenyHosts.constants import DENY_DELIMITER
+
+try:
+    from unittest.mock import patch
+except ImportError:
+    from mock import patch
+
+
+class DenyHostsMigrateTest(unittest.TestCase):
+    def setUp(self):
+        self.directory = ospj(dirname(__file__), 'data/migrate')
+        self.template = ospj(self.directory, 'hosts.deny.template')
+        self.backup = ospj(self.directory, 'hosts.deny.migrate.bak')
+        self.deny_file = "%s/%s" % (self.directory, 'hosts.deny')
+        shutil.copy(self.template, self.deny_file)
+
+    @patch('DenyHosts.denyfileutil.get_user_input', return_value='Yes')
+    def test_migrate(self, input):
+        """
+        Check if Migrate creates a backup file and verify that DENY_DELIMITER
+        has been written to the deny file.
+        """
+        Migrate(self.deny_file)
+        self.assertTrue(filecmp.cmp(self.template, self.backup))
+        self.assertTrue(DENY_DELIMITER in open(self.deny_file).read())
+
+    def tearDown(self):
+        remove(self.deny_file)
+        remove(self.backup)


### PR DESCRIPTION
Fixed user input for python2. 
added test that covers the Migrare class. 
added  mock to requirements.txt for python < 3.3
removed reference to file "/usr/share/doc/denyhosts/README.Debian"

line breaks in DenyHosts/util.py as per [PEP 8 ](https://www.python.org/dev/peps/pep-0008/#blank-lines)