### PR TITLE
Fix successful login detection then using publickey authentication

### DIFF
--- a/DenyHosts/loginattempt.py
+++ b/DenyHosts/loginattempt.py
@@ -69,6 +69,8 @@ class LoginAttempt(object):
             self.__abusive_hosts_valid[host].reset_count()
             # ??? maybe:
             self.__abusive_hosts_invalid[host].reset_count()
+            # reset hosts-root count
+            self.__abusive_hosts_root[host].reset_count()
 
 
         if success and self.__abusive_hosts_invalid[host].get_count() > self.__deny_threshold_invalid: 

--- a/DenyHosts/regex.py
+++ b/DenyHosts/regex.py
@@ -6,7 +6,7 @@ import re
 
 #DATE_FORMAT_REGEX = re.compile(r"""(?P<month>[A-z]{3,3})\s*(?P<day>\d+)""")
 
-SSHD_FORMAT_REGEX = re.compile(r""".* (sshd.*:|\[sshd\]) (?P<message>.*)""")
+SSHD_FORMAT_REGEX = re.compile(r""".* (sshd.*?:|\[sshd\]) (?P<message>.*)""")
 #SSHD_FORMAT_REGEX = re.compile(r""".* sshd.*: (?P<message>.*)""")
 
 FAILED_ENTRY_REGEX = re.compile(r"""Failed (?P<method>\S*) for (?P<invalid>invalid user |illegal user )?(?P<user>.*) from (::ffff:)?(?P<host>\d{1,3}\.\d{1,3}\.\d{1,3}\.\d{1,3})( port \d+)?( ssh2)?$""")
@@ -46,7 +46,7 @@ for i in FAILED_ENTRY_REGEX_RANGE:
     FAILED_ENTRY_REGEX_MAP[i] = rx
 
 
-SUCCESSFUL_ENTRY_REGEX = re.compile(r"""Accepted (?P<method>\S+) for (?P<user>.*) from (::ffff:)?(?P<host>\d{1,3}\.\d{1,3}\.\d{1,3}\.\d{1,3})( port \d+)?( ssh2)?$""")
+SUCCESSFUL_ENTRY_REGEX = re.compile(r"""Accepted (?P<method>\S+) for (?P<user>.*) from (::ffff:)?(?P<host>\d{1,3}\.\d{1,3}\.\d{1,3}\.\d{1,3})( port \d+)?( ssh2)?(: DSA|: RSA)? (SHA256:\S{43})?(\S[0-9a-f]:\S[0-9a-f]:\S[0-9a-f]:\S[0-9a-f]:\S[0-9a-f]:\S[0-9a-f]:\S[0-9a-f]:\S[0-9a-f]:\S[0-9a-f]:\S[0-9a-f]:\S[0-9a-f]:\S[0-9a-f]:\S[0-9a-f]:\S[0-9a-f]:\S[0-9a-f]:\S[0-9a-f])?$""")
 
 TIME_SPEC_REGEX = re.compile(r"""(?P<units>\d*)\s*(?P<period>[smhdwy])?""")
 


### PR DESCRIPTION
Secure log syntax: "Accepted publickey for {user} from {ip} port {port number} ssh2: RSA {key fingerprint}"
This is needed for RESET_ON_SUCCESS to work with publickey authentication.
Also reset failed count for the respective ip in hosts-root file.