### PR TITLE
Support other methods for sending report e-mail

### DIFF
--- a/DenyHosts/prefs.py
+++ b/DenyHosts/prefs.py
@@ -38,6 +38,7 @@ class Prefs(dict):
                        'PFCTL_PATH': None,
                        'PF_TABLE': None,
                        'PF_TABLE_FILE': None,
+                       'EMAIL_METHOD': 'SMTP',
                        'SMTP_HOST': None,
                        'SMTP_PORT': None,
                        'SMTP_USERNAME': None,

--- a/DenyHosts/prefs.py
+++ b/DenyHosts/prefs.py
@@ -39,8 +39,6 @@ class Prefs(dict):
                        'PF_TABLE': None,
                        'PF_TABLE_FILE': None,
                        'EMAIL_METHOD': 'SMTP',
-                       'SMTP_HOST': None,
-                       'SMTP_PORT': None,
                        'SMTP_USERNAME': None,
                        'SMTP_PASSWORD': None,
                        'SMTP_DATE_FORMAT': "%a, %d %b %Y %H:%M:%S %z",

--- a/DenyHosts/prefs.py
+++ b/DenyHosts/prefs.py
@@ -38,6 +38,8 @@ class Prefs(dict):
                        'PFCTL_PATH': None,
                        'PF_TABLE': None,
                        'PF_TABLE_FILE': None,
+                       'SMTP_HOST': None,
+                       'SMTP_PORT': None,
                        'SMTP_USERNAME': None,
                        'SMTP_PASSWORD': None,
                        'SMTP_DATE_FORMAT': "%a, %d %b %Y %H:%M:%S %z",

--- a/DenyHosts/util.py
+++ b/DenyHosts/util.py
@@ -114,46 +114,50 @@ def send_email(prefs, report_str):
 
     msg += report_str
     try:
-        smtp = SMTP()
+        if prefs.get('SMTP_HOST') and prefs.get('SMTP_PORT'):
+            smtp = SMTP()
 
-        if logging.getLogger().isEnabledFor(logging.DEBUG):
-            smtp.set_debuglevel(1)
+            if logging.getLogger().isEnabledFor(logging.DEBUG):
+                smtp.set_debuglevel(1)
 
-        smtp.connect(prefs.get('SMTP_HOST'),
-            prefs.get('SMTP_PORT'))
+            smtp.connect(prefs.get('SMTP_HOST'),
+                prefs.get('SMTP_PORT'))
 
-        # If the server supports ESMTP and TLS, then convert the message exchange to TLS via the
-        # STARTTLS command.
-        if smtp.ehlo()[0] == 250:
-            if smtp.has_extn('starttls'):
-                (code, resp) = smtp.starttls()
-                if code != 220:
-                    raise SMTPResponseException(code, resp)
-                (code, resp) = smtp.ehlo()
-                if code != 250:
-                    raise SMTPResponseException(code, resp)
+            # If the server supports ESMTP and TLS, then convert the message exchange to TLS via the
+            # STARTTLS command.
+            if smtp.ehlo()[0] == 250:
+                if smtp.has_extn('starttls'):
+                    (code, resp) = smtp.starttls()
+                    if code != 220:
+                        raise SMTPResponseException(code, resp)
+                    (code, resp) = smtp.ehlo()
+                    if code != 250:
+                        raise SMTPResponseException(code, resp)
+            else:
+                # The server does not support esmtp.
+
+                # The Python library SMTP class handles executing HELO/EHLO commands inside
+                # login/sendmail methods when neither helo()/ehlo() methods have been
+                # previously called.  Because we have already called ehlo() above, we must
+                # manually fallback to calling helo() here.
+
+                (code, resp) = smtp.helo()
+                if not (200 <= code <= 299):
+                    raise SMTPHeloError(code, resp)
+
+            username = prefs.get('SMTP_USERNAME')
+            password = prefs.get('SMTP_PASSWORD')
+
+            if username and password:
+                smtp.login(username, password)
+
+            smtp.sendmail(prefs.get('SMTP_FROM'),
+                        recipients,
+                        msg)
+            debug("sent email to: %s" % prefs.get("ADMIN_EMAIL"))
         else:
-            # The server does not support esmtp.
-
-            # The Python library SMTP class handles executing HELO/EHLO commands inside
-            # login/sendmail methods when neither helo()/ehlo() methods have been
-            # previously called.  Because we have already called ehlo() above, we must
-            # manually fallback to calling helo() here.
-
-            (code, resp) = smtp.helo()
-            if not (200 <= code <= 299):
-                raise SMTPHeloError(code, resp)
-
-        username = prefs.get('SMTP_USERNAME')
-        password = prefs.get('SMTP_PASSWORD')
-
-        if username and password:
-            smtp.login(username, password)
-
-        smtp.sendmail(prefs.get('SMTP_FROM'),
-                      recipients,
-                      msg)
-        debug("sent email to: %s" % prefs.get("ADMIN_EMAIL"))
+            debug("no SMTP details set...outputting report to stdout")
+            print(msg)
     except Exception as e:
         print("Error sending email")
         print(e)

--- a/DenyHosts/util.py
+++ b/DenyHosts/util.py
@@ -3,6 +3,8 @@ import logging.handlers
 from smtplib import SMTP
 from smtplib import SMTPResponseException
 from smtplib import SMTPHeloError
+from email.mime.text import MIMEText
+from subprocess import Popen, PIPE
 import sys
 from textwrap import dedent
 import time
@@ -97,24 +99,24 @@ def parse_host(line):
 
 def send_email(prefs, report_str):
     recipients = prefs['ADMIN_EMAIL'].split(',')
-
-    msg = dedent("""
-        From: %s
-        To: %s
-        Subject: %s
-        Date: %s
-
-        """).lstrip() % (
-            prefs.get('SMTP_FROM'),
-            prefs.get('ADMIN_EMAIL'),
-            prefs.get('SMTP_SUBJECT'),
-            time.strftime(prefs.get('SMTP_DATE_FORMAT')
-        )
-    )
-
-    msg += report_str
     try:
-        if prefs.get('SMTP_HOST') and prefs.get('SMTP_PORT'):
+        method = prefs.get('EMAIL_METHOD')
+        if method == 'SMTP':
+            msg = dedent("""
+                From: %s
+                To: %s
+                Subject: %s
+                Date: %s
+
+                """).lstrip() % (
+                    prefs.get('SMTP_FROM'),
+                    prefs.get('ADMIN_EMAIL'),
+                    prefs.get('SMTP_SUBJECT'),
+                    time.strftime(prefs.get('SMTP_DATE_FORMAT')
+                )
+            )
+
+            msg += report_str
             smtp = SMTP()
 
             if logging.getLogger().isEnabledFor(logging.DEBUG):
@@ -155,14 +157,25 @@ def send_email(prefs, report_str):
                         recipients,
                         msg)
             debug("sent email to: %s" % prefs.get("ADMIN_EMAIL"))
+        elif method == 'SENDMAIL':
+            msg = MIMEText(report_str)
+            msg["From"] = prefs.get("SMTP_FROM")
+            msg["To"] = prefs.get("ADMIN_EMAIL")
+            msg["Subject"] = prefs.get("SMTP_SUBJECT")
+            p = Popen(["/usr/sbin/sendmail", "-t", "-oi"], stdin=PIPE)
+            p.communicate(msg.as_string())
+        elif method == 'MAIL':
+            p = Popen(['mail', '-s', prefs.get("SMTP_SUBJECT")] + recipients, stdin=PIPE)
+            p.communicate(report_str)
+        elif method == 'STDOUT': 
+            print(report_str)
         else:
-            debug("no SMTP details set...outputting report to stdout")
-            print(msg)
+            raise Exception("Unknown e-mail method: %s" % method)
     except Exception as e:
         print("Error sending email")
         print(e)
         print("Email message follows:")
-        print(msg)
+        print(report_str)
 
     try:
         smtp.quit()


### PR DESCRIPTION
As far as I know, there aren't any open SMTP relays anymore.  Even ISPs don't seem to offer them.  So, the SMTP method of sending e-mail is pretty limited.

On my particular system, I've configured postfix to use gmail as an SMTP relay.  This means that DenyHosts doesn't need to know the SMTP details, it can just use existing utilities to send mail.  These include the "mail" and "sendmail" commands.  Also, for completeness, I've added a method to just print the message to stdout.  Since DenyHosts can be run as a cron job, we can leave it up to cron to e-mail what we print to stdout to the appropriate mailbox.