### PR TITLE
fixed logic error in process_log

### DIFF
--- a/DenyHosts/deny_hosts.py
+++ b/DenyHosts/deny_hosts.py
@@ -445,17 +445,15 @@ allowed based on your %s file""" % (self.__prefs.get("HOSTS_DENY"),
                     m = self.__successful_entry_regex.match(message)
                     if m:
                         success = 1
-
             # otherwise, did the line match a failed dovelog login attempt?
-            if is_true(self.__prefs.get("DETECT_DOVECOT_LOGIN_ATTEMPTS")):
+            elif is_true(self.__prefs.get("DETECT_DOVECOT_LOGIN_ATTEMPTS")):
                 rxx = self.__failed_dovecot_entry_regex
                 m = rxx.search(line)
                 if m:
                     # debug("matched (host=%s): %s", m.group("host"), rx.pattern)
                     invalid = self.is_valid(m)
-
             # otherwise, did the line match one of the userdef regexes?
-            if not m:
+            elif not m:
                 for rxx in self.__prefs.get('USERDEF_FAILED_ENTRY_REGEX'):
                     m = rxx.search(line)
                     if m:


### PR DESCRIPTION
This bug presents itself when either `DETECT_DOVECOT_LOGIN_ATTEMPTS` or `USERDEF_FAILED_ENTRY_REGEX` are set which causes sshd messages such as this to fail to be processed...

```
Dec 27 12:19:49 mail sshd[26531]: Invalid user linchang from 104.236.142.200 port 34388
```