### PR TITLE
fix(denyhosts.service): adopt update directories  /

### DIFF
--- a/denyhosts.conf
+++ b/denyhosts.conf
@@ -221,7 +221,7 @@ HOSTNAME_LOOKUP=NO
 #LOCK_FILE = /var/lock/subsys/denyhosts
 #
 # Debian or Gentoo
-LOCK_FILE = /var/run/denyhosts.pid
+LOCK_FILE = /run/denyhosts.pid
 #
 # Misc
 #LOCK_FILE = /tmp/denyhosts.lock

--- a/denyhosts.service
+++ b/denyhosts.service
@@ -4,9 +4,9 @@ Before=sshd.service
 
 [Service]
 Type=forking
-ExecStartPre=/bin/rm -f /var/run/denyhosts.pid
-ExecStart=/usr/bin/denyhosts.py --daemon --config=/etc/denyhosts.conf
-PIDFile=/var/run/denyhosts.pid
+ExecStartPre=/bin/rm -f /run/denyhosts.pid
+ExecStart=/usr/local/bin/denyhosts.py --daemon --config=/etc/denyhosts.conf
+PIDFile=/run/denyhosts.pid
 
 [Install]
 WantedBy=multi-user.target


### PR DESCRIPTION
var/run → /run 
/usr/bin → /usr/local/bin

- Systemd otherwise complains about legacy PID file location
- Service won't start due install.py installing in other directory