### PR TITLE
fixed string formatting errors

### DIFF
--- a/DenyHosts/firewalls.py
+++ b/DenyHosts/firewalls.py
@@ -36,23 +36,23 @@ class IpTables(object):
             rule = self.__create_singleport_rule(block_ip)
         else:
             rule = self.__create_block_all_rule(block_ip)
-        return '%s -I ' % rule
+        return '%s -I %s' % (self.__iptables, rule)
 
     def __create_singleport_rule(self, block_ip):
         debug("Generating INPUT block single port rule")
         sp_rule = "INPUT -p tcp --dport %s -s %s -j DROP" % \
-                  (self.__iptables, self.__blockport, block_ip)
+                  (self.__blockport, block_ip)
         return sp_rule
 
     def __create_multiport_rule(self, block_ip):
         debug("Generating INPUT block multi-port rule")
         mp_rule = "INPUT -p tcp -m multiport --dports %s -s %s -j DROP" % \
-                  (self.__iptables, self.__blockport, block_ip)
+                  (self.__blockport, block_ip)
         return mp_rule
 
     def __create_block_all_rule(self, block_ip):
         debug("Generating INPUT block all ports rule")
-        ba_rule = "INPUT -s %s -j DROP" % (self.__iptables, block_ip)
+        ba_rule = "INPUT -s %s -j DROP" % (block_ip)
         return ba_rule
 
     def remove_ips(self, ip_list):
@@ -76,4 +76,4 @@ class IpTables(object):
             rule = self.__create_singleport_rule(blocked_ip)
         else:
             rule = self.__create_block_all_rule(blocked_ip)
-        return '%s -D ' % rule
+        return '%s -D %s' % (self.__iptables, rule)


### PR DESCRIPTION
This fixes errors similar to this caused by #164 
```
2020-09-08 22:11:08,531 - firewalls   : ERROR    Unable to write new firewall rule with error: not all arguments converted during string formatting                                                                 
Traceback (most recent call last):                                                                                          
  File "/usr/local/lib/python2.7/dist-packages/DenyHosts/firewalls.py", line 23, in block_ips
    new_rule = self.__create_rule(block_ip)                                          
  File "/usr/local/lib/python2.7/dist-packages/DenyHosts/firewalls.py", line 38, in __create_rule
    rule = self.__create_block_all_rule(block_ip)                                     
  File "/usr/local/lib/python2.7/dist-packages/DenyHosts/firewalls.py", line 56, in __create_block_all_rule                            
    ba_rule = "INPUT -s %s -j DROP" % (self.__iptables, block_ip)                                                                                
TypeError: not all arguments converted during string formatting  
```