### PR TITLE
fix crash on ip address not being an ip address

### DIFF
--- a/DenyHosts/util.py
+++ b/DenyHosts/util.py
@@ -217,12 +217,15 @@ def hostname_lookup(process_host):
 
 def is_valid_ip_address(process_ip):
     ip = None
-    if py_version[0] == 2:
-        # python 2
-        ip = IPAddress(process_ip)
-    elif py_version[0] == 3:
-        # python 3
-        ip = ip_address(process_ip)
+    try:
+        if py_version[0] == 2:
+            # python 2
+            ip = IPAddress(process_ip)
+        elif py_version[0] == 3:
+            # python 3
+            ip = ip_address(process_ip)
+    except:
+        pass
 
     if ip is None or ip.is_reserved or ip.is_private or \
             ip.is_loopback or ip.is_unspecified or \


### PR DESCRIPTION
got this crash today:

Starting denyhosts.
Traceback (most recent call last):
  File "/usr/local/bin/denyhosts.py", line 232, in <module>
    first_time, noemail, daemon, foreground)
  File "/usr/local/lib/python3.7/site-packages/DenyHosts/deny_hosts.py", line 85, in __init__
    offset = self.process_log(logfile, last_offset)
  File "/usr/local/lib/python3.7/site-packages/DenyHosts/deny_hosts.py", line 481, in process_log
    if not is_valid_ip_address(host):
  File "/usr/local/lib/python3.7/site-packages/DenyHosts/util.py", line 200, in is_valid_ip_address
    ip = ip_address(process_ip)
  File "/usr/local/lib/python3.7/ipaddress.py", line 54, in ip_address
    address)
ValueError: '0x31c6b90c.my.ip.provider.net' does not appear to be an IPv4 or IPv6 address
