### PR TITLE
Username / password data should not be allowed in a world readable lo…

### DIFF
--- a/DenyHosts/prefs.py
+++ b/DenyHosts/prefs.py
@@ -234,5 +234,10 @@ class Prefs(dict):
             if key == 'USERDEF_FAILED_ENTRY_REGEX':
                 for rx in self.__data[key]:
                     info("   %s: [%s]" % (key, rx.pattern))
+            elif (key == 'SMTP_PASSWORD') or (key == 'SMTP_USERNAME'):
+                if self.__data[key] is not None:
+                    info("   %s: [%s]", key, r"<redacted>")
+                else:
+                    info("   %s: [%s]", key, self.__data[key])
             else:
                 info("   %s: [%s]", key, self.__data[key])


### PR DESCRIPTION
Alternate email methods were not being attempted unless SMTP failed or at all if SMTP raised and exception which seems to be always with recent python3 versions.

This PR will correctly use the method defined by the EMAIL_METHOD preferences, and fixed a python3 issue with the SENDMAIL method.

Also logs an error on email failure so they can be at least known to be occurring.