### PR TITLE
fixes issue where denyhosts would break in python 3.12

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -7,7 +7,7 @@ import sys
 from os.path import join as ospj
 from os.path import exists as fcheck
 
-from distutils.core import setup
+from setuptools import setup
 
 from DenyHosts.util import normalize_whitespace
 from DenyHosts.version import VERSION


### PR DESCRIPTION
changing to using setuptools instead of distutils.  